### PR TITLE
Fixes issue #7 Setting value just after building a gauge with Dashboa…

### DIFF
--- a/src/main/java/eu/hansolo/medusa/skins/DashboardSkin.java
+++ b/src/main/java/eu/hansolo/medusa/skins/DashboardSkin.java
@@ -219,7 +219,7 @@ public class DashboardSkin extends SkinBase<Gauge> implements Skin<Gauge> {
 
     // ******************** Private Methods ***********************************
     private void setBar(final double VALUE) {
-        currentValueAngle = Helper.clamp(90d, 270d, (VALUE + Math.abs(minValue)) * angleStep + 90d);
+        currentValueAngle = Helper.clamp(90d, 270d, (VALUE - minValue) * angleStep + 90d);
         dataBarOuterArc.setX(centerX + (0.675 * height) * Math.sin(-Math.toRadians(currentValueAngle)));
         dataBarOuterArc.setY(centerX + (0.675 * height) * Math.cos(-Math.toRadians(currentValueAngle)));
         dataBarLineToInnerArc.setX(centerX + (0.3 * height) * Math.sin(-Math.toRadians(currentValueAngle)));
@@ -233,7 +233,7 @@ public class DashboardSkin extends SkinBase<Gauge> implements Skin<Gauge> {
         if (!sectionsVisible && !colorGradientEnabled) {
             dataBar.setFill(getSkinnable().getBarColor());
         } else if (colorGradientEnabled && noOfGradientStops > 1) {
-            dataBar.setFill(getSkinnable().getGradientLookup().getColorAt(VALUE / range));
+            dataBar.setFill(getSkinnable().getGradientLookup().getColorAt((VALUE - minValue) / range));
         } else {
             for (Section section : sections) {
                 if (section.contains(VALUE)) {
@@ -325,7 +325,7 @@ public class DashboardSkin extends SkinBase<Gauge> implements Skin<Gauge> {
             barBackgroundInnerArc.setX(0.27778 * width);
             barBackgroundInnerArc.setY(0.675 * height);
 
-            currentValueAngle = (getSkinnable().getCurrentValue() + Math.abs(minValue)) * angleStep + 90;
+            currentValueAngle = (getSkinnable().getCurrentValue() - minValue) * angleStep + 90;
             dataBarStart.setX(0);
             dataBarStart.setY(0.675 * height);
             dataBarOuterArc.setRadiusX(0.675 * height);

--- a/src/main/java/eu/hansolo/medusa/tools/Helper.java
+++ b/src/main/java/eu/hansolo/medusa/tools/Helper.java
@@ -132,7 +132,7 @@ public class Helper {
 
     public static final void adjustTextSize(final Text TEXT, final double MAX_WIDTH, double fontSize) {
         final String FONT_NAME = TEXT.getFont().getName();
-        while (TEXT.getLayoutBounds().getWidth() > MAX_WIDTH | fontSize < 0) {
+        while (TEXT.getLayoutBounds().getWidth() > MAX_WIDTH && fontSize > 0) {
             fontSize -= 0.005;
             TEXT.setFont(new Font(FONT_NAME, fontSize));
         }


### PR DESCRIPTION
…rdSkin locks the application

* Fixed adjustTextSize method condition and avoid infinite loop

Problem is that the condition in the loop does not do what is expected. Also the loop enters in an infinite loop when MAX_WIDTH and fontSize are zero, something that happens in the OverviewDemo because the gauge has not been rendered for the first time and all initial sizes are zero.