### PR TITLE
Added MANIFEST.MF headers for OSGi compatibility.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,14 @@
 import java.text.SimpleDateFormat
 
+buildscript {
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath 'biz.aQute.bnd:biz.aQute.bnd.gradle:3.0.0'
+  }
+}
+	
 // Medusa main build file
 plugins {
     id 'idea'
@@ -8,6 +17,10 @@ plugins {
     id 'net.nemerosa.versioning' version '1.6.0'
     id 'com.jfrog.bintray' version '1.6'
 }
+
+apply plugin: 'biz.aQute.bnd.builder'
+
+description = 'Medusa is a JavaFX 8 library containing gauges and clocks'
 
 Date buildTimeAndDate = new Date()
 ext {
@@ -26,7 +39,11 @@ jar {
                 'Specification-Title': project.name,
                 'Specification-Version': project.version,
                 'Implementation-Title': project.name,
-                'Implementation-Version': project.version
+                'Implementation-Version': project.version,
+                'Bundle-Name': project.name,
+                'Bundle-License': 'https://www.apache.org/licenses/LICENSE-2.0;description=Apache License Version 2.0;link=https://www.eclipse.org/legal/eplfaq.php',
+                'Bundle-Description': description,
+                'Export-Package': 'eu.hansolo.medusa,eu.hansolo.medusa.tools,eu.hansolo.medusa.skins,eu.hansolo.medusa.events'
         )
     }
 }
@@ -89,7 +106,7 @@ publishing {
 
             pom.withXml {
                 asNode().children().last() + pomConfig
-                asNode().appendNode('description', 'Medusa is a JavaFX 8 library containing gauges and clocks')
+                asNode().appendNode('description', description)
             }
         }
     }
@@ -106,7 +123,7 @@ bintray {
         repo                  = 'Medusa'
         userOrg               = 'hansolo'
         name                  = project.name
-        desc                  = 'Medusa is a JavaFX 8 gauges library'
+        desc                  = description
         licenses              = ['Apache-2.0']
         labels                = ['javafx']
         websiteUrl            = 'https://github.com/HanSolo/Medusa/wiki'


### PR DESCRIPTION
Uses bnd plugin to add headers for deployment into an OSGi container.
Tested on Apache Felix 5.4.0

I've noticed a different mechanism of Gradle plugin usage, used the way I know.