### PR TITLE
Remove printing debug information to System.out

### DIFF
--- a/src/main/java/eu/hansolo/medusa/skins/LcdClockSkin.java
+++ b/src/main/java/eu/hansolo/medusa/skins/LcdClockSkin.java
@@ -575,8 +575,6 @@ public class LcdClockSkin extends SkinBase<Clock> implements Skin<Clock> {
             height = ASPECT_RATIO * width;
         }
 
-        System.out.println("Clock: " + width + ", " + height);
-
         if (width > 0 && height > 0) {
             pane.setMaxSize(width, height);
             pane.relocate((getSkinnable().getWidth() - width) * 0.5, (getSkinnable().getHeight() - height) * 0.5);

--- a/src/main/java/eu/hansolo/medusa/skins/LcdSkin.java
+++ b/src/main/java/eu/hansolo/medusa/skins/LcdSkin.java
@@ -502,8 +502,6 @@ public class LcdSkin extends SkinBase<Gauge> implements Skin<Gauge> {
             height = aspectRatio * width;
         }
 
-        System.out.println("Gauge: " + width + ", " + height);
-
         if (width > 0 && height > 0) {
             pane.setMaxSize(width, height);
             pane.relocate((getSkinnable().getWidth() - width) * 0.5, (getSkinnable().getHeight() - height) * 0.5);


### PR DESCRIPTION
This PR removes the printing of width and height of the LcdClockSkin and LcdSkin at each resize.