### PR TITLE
Sections and background in BAR skin

### DIFF
--- a/src/main/java/eu/hansolo/medusa/GaugeBuilder.java
+++ b/src/main/java/eu/hansolo/medusa/GaugeBuilder.java
@@ -25,6 +25,10 @@ import eu.hansolo.medusa.Gauge.NeedleType;
 import eu.hansolo.medusa.Gauge.ScaleDirection;
 import eu.hansolo.medusa.Gauge.SkinType;
 import eu.hansolo.medusa.tools.GradientLookup;
+import java.text.NumberFormat;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
 import javafx.beans.InvalidationListener;
 import javafx.beans.property.BooleanProperty;
 import javafx.beans.property.DoubleProperty;
@@ -48,11 +52,6 @@ import javafx.scene.paint.Color;
 import javafx.scene.paint.Paint;
 import javafx.scene.paint.Stop;
 import javafx.scene.text.Font;
-
-import java.text.NumberFormat;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
 
 
 /**
@@ -1004,6 +1003,7 @@ public class GaugeBuilder<B extends GaugeBuilder<B>> {
                                                 new Stop(0.75, barColor.deriveColor(-10, 1, 1, 1)),
                                                 new Stop(1.0, barColor.deriveColor(-20, 1, 1, 1)));
                     CONTROL.setBarColor(barColor);
+                    CONTROL.setBarEffectEnabled(true);
                     break;
                 case WHITE:
                     CONTROL.setAnimated(true);

--- a/src/main/java/eu/hansolo/medusa/Test.java
+++ b/src/main/java/eu/hansolo/medusa/Test.java
@@ -81,7 +81,10 @@ public class Test extends Application {
 
 
         gauge = GaugeBuilder.create()
-                            .skinType(SkinType.AMP)
+                            .skinType(SkinType.BAR)
+                            .barColor(Color.CORAL)
+                            .barEffectEnabled(false)
+                            .backgroundPaint(Color.ANTIQUEWHITE)
                             //.prefSize(400, 400)
                             //.knobPosition(Pos.TOP_RIGHT)
                             .minValue(-20)

--- a/src/main/java/eu/hansolo/medusa/skins/BarSkin.java
+++ b/src/main/java/eu/hansolo/medusa/skins/BarSkin.java
@@ -19,11 +19,18 @@ package eu.hansolo.medusa.skins;
 import eu.hansolo.medusa.Fonts;
 import eu.hansolo.medusa.Gauge;
 import eu.hansolo.medusa.Gauge.ScaleDirection;
+import eu.hansolo.medusa.Section;
 import eu.hansolo.medusa.tools.ConicalGradient;
 import eu.hansolo.medusa.tools.Helper;
+import java.util.List;
+import java.util.Locale;
 import javafx.beans.InvalidationListener;
+import javafx.geometry.Insets;
 import javafx.scene.effect.BlurType;
 import javafx.scene.effect.DropShadow;
+import javafx.scene.layout.Background;
+import javafx.scene.layout.BackgroundFill;
+import javafx.scene.layout.CornerRadii;
 import javafx.scene.layout.Pane;
 import javafx.scene.paint.Color;
 import javafx.scene.paint.Stop;
@@ -33,9 +40,6 @@ import javafx.scene.shape.Rectangle;
 import javafx.scene.shape.StrokeLineCap;
 import javafx.scene.shape.StrokeType;
 import javafx.scene.text.Text;
-
-import java.util.List;
-import java.util.Locale;
 
 
 /**
@@ -59,6 +63,8 @@ public class BarSkin extends GaugeSkinBase {
     private              double          angleStep;
     private              String          formatString;
     private              Locale          locale;
+    private              boolean         sectionsVisible;
+    private              List<Section>   sections;
     private              InvalidationListener currentValueListener;
     private              InvalidationListener barColorListener;
     private              InvalidationListener titleListener;
@@ -73,6 +79,8 @@ public class BarSkin extends GaugeSkinBase {
         angleStep            = -ANGLE_RANGE / range;
         formatString         = new StringBuilder("%.").append(Integer.toString(gauge.getDecimals())).append("f").toString();
         locale               = gauge.getLocale();
+        sectionsVisible      = gauge.getSectionsVisible();
+        sections             = gauge.getSections();
         currentValueListener = o -> redraw();
         barColorListener     = o -> {
             Color barColor = gauge.getBarColor();
@@ -116,8 +124,10 @@ public class BarSkin extends GaugeSkinBase {
 
         shadow = new DropShadow(BlurType.TWO_PASS_BOX, Color.rgb(0, 0, 0, 0.45), 0.01 * PREFERRED_WIDTH, 0, 0.01 * PREFERRED_WIDTH, 0);
 
+        Color barBackgroundColor = gauge.getBarBackgroundColor();
         circle = new Circle();
         circle.setFill(null);
+        circle.setStroke(Color.color(barBackgroundColor.getRed(), barBackgroundColor.getGreen(), barBackgroundColor.getBlue(), 0.13));
 
         arc = new Arc(PREFERRED_WIDTH * 0.5, PREFERRED_HEIGHT * 0.5, PREFERRED_WIDTH * 0.96, PREFERRED_WIDTH * 0.48, 90, 0);
         arc.setStrokeWidth(PREFERRED_WIDTH * 0.008);
@@ -149,6 +159,7 @@ public class BarSkin extends GaugeSkinBase {
         Helper.enableNode(unitText, !gauge.getUnit().isEmpty());
 
         pane = new Pane(circle, arc, fakeDot, dot, titleText, valueText, unitText);
+        pane.setBackground(new Background(new BackgroundFill(gauge.getBackgroundPaint(), new CornerRadii(1024), Insets.EMPTY)));
 
         getChildren().setAll(pane);
     }
@@ -168,6 +179,7 @@ public class BarSkin extends GaugeSkinBase {
         if ("RECALC".equals(EVENT_TYPE)) {
             range     = gauge.getRange();
             angleStep = -ANGLE_RANGE / range;
+            sections  = gauge.getSections();
             redraw();
         }
     }
@@ -180,6 +192,24 @@ public class BarSkin extends GaugeSkinBase {
         super.dispose();
     }
 
+    private void setBarBackgroundColor(final double VALUE) {
+
+        Color barBackgroundColor = gauge.isBarEffectEnabled()
+                                 ? gauge.getBarColor()
+                                 : gauge.getBarBackgroundColor();
+
+        if ( sectionsVisible ) {
+            for (Section section : sections) {
+                if (section.contains(VALUE)) {
+                    barBackgroundColor = section.getColor();
+                    break;
+                }
+            }
+        }
+
+        circle.setStroke(Color.color(barBackgroundColor.getRed(), barBackgroundColor.getGreen(), barBackgroundColor.getBlue(), 0.13));
+            
+    }
 
     // ******************** Resizing ******************************************
     private void resizeTitleText() {
@@ -237,7 +267,7 @@ public class BarSkin extends GaugeSkinBase {
             double     currentValue     = gauge.getCurrentValue();
             List<Stop> gradientBarStops = gauge.getGradientBarStops();
 
-            circle.setStroke(Color.color(barColor.getRed(), barColor.getGreen(), barColor.getBlue(), 0.13));
+            setBarBackgroundColor(gauge.getCurrentValue());
 
             Rectangle bounds = new Rectangle(0, 0, size, size);
 
@@ -265,9 +295,15 @@ public class BarSkin extends GaugeSkinBase {
     }
 
     @Override protected void redraw() {
+        pane.setBackground(new Background(new BackgroundFill(gauge.getBackgroundPaint(), new CornerRadii(1024), Insets.EMPTY)));
+
         double currentValue = gauge.getCurrentValue();
         double angle        = currentValue * angleStep;
         double rotate       = angle  < -360 ? angle  + 360 : 0;
+
+        sectionsVisible = gauge.getSectionsVisible();
+
+        setBarBackgroundColor(gauge.getCurrentValue());
 
         arc.setRotate(-rotate);
         arc.setLength(Helper.clamp(-360.0, 0.0, angle));


### PR DESCRIPTION
If no sections, the behaviour is like before.

If there are sections, the bar’s background changes to a fancy version
of the section’s color.

If barEffects is false (default is true), the bar’s background outside
sections is coloured using the barBacgroundColor. When barEffects is
true, the default fancy color derived from the barColor is used.

Moreover, the background property was missing and I’ve added it too.