### PR TITLE
Bad behaviour when range does not contain zero in SIMPLE SECTION

### DIFF
--- a/src/main/java/eu/hansolo/medusa/GaugeBuilder.java
+++ b/src/main/java/eu/hansolo/medusa/GaugeBuilder.java
@@ -1024,6 +1024,7 @@ public class GaugeBuilder<B extends GaugeBuilder<B>> {
                     CONTROL.setAnimated(true);
                     CONTROL.setStartAngle(150);
                     CONTROL.setAngleRange(300);
+                    CONTROL.setStartFromZero(true);
                     CONTROL.setSectionsVisible(true);
                     CONTROL.setBarBackgroundColor(Color.rgb(150, 150, 150, 0.25));
                     CONTROL.setBarColor(Color.rgb(69, 106, 207));

--- a/src/main/java/eu/hansolo/medusa/Test.java
+++ b/src/main/java/eu/hansolo/medusa/Test.java
@@ -81,13 +81,14 @@ public class Test extends Application {
                               .build();
 
         gauge = GaugeBuilder.create()
-                            .skinType(SkinType.AMP)
+                            .skinType(SkinType.SIMPLE_SECTION)
                             //.prefSize(400, 400)
                             .knobPosition(Pos.BOTTOM_LEFT)
                             .tickLabelLocation(TickLabelLocation.OUTSIDE)
-                            .decimals(0)
+                            .decimals(2)
                             .minValue(-20)
                             .maxValue(100)
+                            .startFromZero(true)
                             .animated(true)
                             //.checkThreshold(true)
                             //.onThresholdExceeded(e -> System.out.println("threshold exceeded"))
@@ -127,7 +128,7 @@ public class Test extends Application {
         //gauge.setAlert(true);
 
         // Calling bind() directly sets a value to gauge
-        gauge.valueProperty().bind(value);
+        gauge.valueProperty().bindBidirectional(value);
 
         gauge.getSections().forEach(section -> section.setOnSectionUpdate(sectionEvent -> gauge.fireUpdateEvent(new UpdateEvent(Test.this, EventType.REDRAW))));
 
@@ -160,7 +161,7 @@ public class Test extends Application {
 
             @Override public void handle(long now) {
                 if (now > lastTimerCall + 3_000_000_000l) {
-                    double v = RND.nextDouble() * gauge.getRange() * 1.1 + gauge.getMinValue();
+                    double v = gauge.getRange() * ( RND.nextDouble() * 1.3 - 0.15 ) + gauge.getMinValue();
                     value.set(v);
                     //System.out.println(v);
                     //gauge.setValue(v);

--- a/src/main/java/eu/hansolo/medusa/skins/SimpleSectionSkin.java
+++ b/src/main/java/eu/hansolo/medusa/skins/SimpleSectionSkin.java
@@ -151,17 +151,40 @@ public class SimpleSectionSkin extends GaugeSkinBase {
 
 
     // ******************** Canvas ********************************************
-    private void setBar(final double VALUE) {
-        bar.setStartAngle(gauge.getStartAngle() + 90 + gauge.getMinValue() * gauge.getAngleStep());
-        if (gauge.getMinValue() > 0) {
-            bar.setLength((gauge.getMinValue() - VALUE) * gauge.getAngleStep());
+    private void setBar( final double VALUE ) {
+
+        double barLength = 0;
+        double barStart = 0;
+        double min = gauge.getMinValue();
+        double max = gauge.getMaxValue();
+        double step = gauge.getAngleStep();
+        double clampedValue = Helper.clamp(min, max, VALUE);
+
+        if ( gauge.isStartFromZero() ) {
+            if ( ( VALUE > min || min < 0 ) && ( VALUE < max || max > 0 ) ) {
+                if ( max < 0 ) {
+                    barStart = gauge.getStartAngle() + 90 - gauge.getAngleRange();
+                    barLength = ( max - clampedValue ) * step;
+                } else if ( min > 0 ) {
+                    barStart = gauge.getStartAngle() + 90;
+                    barLength = ( min - clampedValue ) * step;
+                } else {
+                    barStart = gauge.getStartAngle() + 90 + min * step;
+                    barLength = - clampedValue * step;
+                }
+            }
         } else {
-            bar.setLength(-VALUE * gauge.getAngleStep());
+            barStart = gauge.getStartAngle() + 90;
+            barLength = ( min - clampedValue ) * step;
         }
-        if (gauge.getSectionsVisible() && !sections.isEmpty()) {
+        
+        bar.setStartAngle(barStart);
+        bar.setLength(barLength);
+
+        if ( gauge.getSectionsVisible() && !sections.isEmpty() ) {
             bar.setStroke(gauge.getBarColor());
-            for (Section section : sections) {
-                if (section.contains(VALUE)) {
+            for ( Section section : sections ) {
+                if ( section.contains(VALUE) ) {
                     bar.setStroke(section.getColor());
                     break;
                 }
@@ -170,6 +193,7 @@ public class SimpleSectionSkin extends GaugeSkinBase {
 
         valueText.setText(String.format(gauge.getLocale(), formatString, VALUE));
         valueText.setLayoutX((size - valueText.getLayoutBounds().getWidth()) * 0.5);
+
     }
 
     private void drawBackground() {


### PR DESCRIPTION
When startFromZero is true (default) bad behaviour happened in
SIMPLE_SELECTION skin if zero is not included inside the range.
Now the behaviour is correct (e.g. bar starting from max if max < 0)
and clamping was fixed too.