### PR TITLE
Bad behaviour when range does not contain zero in SLIM

### DIFF
--- a/src/main/java/eu/hansolo/medusa/GaugeBuilder.java
+++ b/src/main/java/eu/hansolo/medusa/GaugeBuilder.java
@@ -916,6 +916,7 @@ public class GaugeBuilder<B extends GaugeBuilder<B>> {
                 case SLIM        :
                     CONTROL.setKnobPosition(Pos.CENTER);
                     CONTROL.setDecimals(2);
+                    CONTROL.setStartFromZero(true);
                     CONTROL.setBarBackgroundColor(Color.rgb(62, 67, 73));
                     CONTROL.setBarColor(Color.rgb(93,190,205));
                     CONTROL.setTitleColor(Color.rgb(142,147,151));

--- a/src/main/java/eu/hansolo/medusa/Test.java
+++ b/src/main/java/eu/hansolo/medusa/Test.java
@@ -81,13 +81,14 @@ public class Test extends Application {
                               .build();
 
         gauge = GaugeBuilder.create()
-                            .skinType(SkinType.AMP)
+                            .skinType(SkinType.SLIM)
                             //.prefSize(400, 400)
                             .knobPosition(Pos.BOTTOM_LEFT)
                             .tickLabelLocation(TickLabelLocation.OUTSIDE)
-                            .decimals(0)
-                            .minValue(-20)
+                            .decimals(2)
+                            .minValue(20)
                             .maxValue(100)
+                            .startFromZero(true)
                             .animated(true)
                             //.checkThreshold(true)
                             //.onThresholdExceeded(e -> System.out.println("threshold exceeded"))
@@ -127,7 +128,7 @@ public class Test extends Application {
         //gauge.setAlert(true);
 
         // Calling bind() directly sets a value to gauge
-        gauge.valueProperty().bind(value);
+        gauge.valueProperty().bindBidirectional(value);
 
         gauge.getSections().forEach(section -> section.setOnSectionUpdate(sectionEvent -> gauge.fireUpdateEvent(new UpdateEvent(Test.this, EventType.REDRAW))));
 
@@ -160,7 +161,7 @@ public class Test extends Application {
 
             @Override public void handle(long now) {
                 if (now > lastTimerCall + 3_000_000_000l) {
-                    double v = RND.nextDouble() * gauge.getRange() * 1.1 + gauge.getMinValue();
+                    double v = gauge.getRange() * ( RND.nextDouble() * 1.3 - 0.15 ) + gauge.getMinValue();
                     value.set(v);
                     //System.out.println(v);
                     //gauge.setValue(v);

--- a/src/main/java/eu/hansolo/medusa/skins/SlimSkin.java
+++ b/src/main/java/eu/hansolo/medusa/skins/SlimSkin.java
@@ -152,17 +152,36 @@ public class SlimSkin extends GaugeSkinBase {
         }
     }
 
-    private void setBar(final double VALUE) {
-        if (minValue > 0) {
-            bar.setLength((minValue - VALUE) * angleStep);
+    private void setBar( final double VALUE ) {
+
+        double barLength = 0;
+        double min = gauge.getMinValue();
+        double max = gauge.getMaxValue();
+        double clampedValue = Helper.clamp(min, max, VALUE);
+
+        if ( gauge.isStartFromZero() ) {
+            if ( ( VALUE > min || min < 0 ) && ( VALUE < max || max > 0 ) ) {
+                if ( max < 0 ) {
+                    barLength = ( max - clampedValue ) * angleStep;
+                } else if ( min > 0 ) {
+                    barLength = ( min - clampedValue ) * angleStep;
+                } else {
+                    barLength = - clampedValue * angleStep;
+                }
+            }
         } else {
-            bar.setLength(-VALUE * angleStep);
+            barLength = ( min - clampedValue ) * angleStep;
         }
+
+        bar.setLength(barLength);
+
         setBarColor(VALUE);
         valueText.setText(String.format(locale, formatString, VALUE));
         resizeValueText();
+
     }
-    private void setBarColor(final double VALUE) {
+
+    private void setBarColor( final double VALUE ) {
         if (!sectionsVisible && !colorGradientEnabled) {
             bar.setStroke(gauge.getBarColor());
         } else if (colorGradientEnabled && noOfGradientStops > 1) {


### PR DESCRIPTION
When startFromZero is true (default) bad behaviour happened in
SLIM skin if zero is not included inside the range.
Now the behaviour is correct (e.g. bar starting from max if max < 0)
and clamping was fixed too.