### PR TITLE
Zero segment not highlighted in DIGITAL when start from zero

### DIFF
--- a/src/main/java/eu/hansolo/medusa/Test.java
+++ b/src/main/java/eu/hansolo/medusa/Test.java
@@ -81,13 +81,14 @@ public class Test extends Application {
                               .build();
 
         gauge = GaugeBuilder.create()
-                            .skinType(SkinType.AMP)
+                            .skinType(SkinType.DIGITAL)
                             //.prefSize(400, 400)
                             .knobPosition(Pos.BOTTOM_LEFT)
                             .tickLabelLocation(TickLabelLocation.OUTSIDE)
-                            .decimals(0)
+                            .decimals(2)
                             .minValue(-20)
                             .maxValue(100)
+                            .startFromZero(true)
                             .animated(true)
                             //.checkThreshold(true)
                             //.onThresholdExceeded(e -> System.out.println("threshold exceeded"))
@@ -127,7 +128,7 @@ public class Test extends Application {
         //gauge.setAlert(true);
 
         // Calling bind() directly sets a value to gauge
-        gauge.valueProperty().bind(value);
+        gauge.valueProperty().bindBidirectional(value);
 
         gauge.getSections().forEach(section -> section.setOnSectionUpdate(sectionEvent -> gauge.fireUpdateEvent(new UpdateEvent(Test.this, EventType.REDRAW))));
 
@@ -160,7 +161,7 @@ public class Test extends Application {
 
             @Override public void handle(long now) {
                 if (now > lastTimerCall + 3_000_000_000l) {
-                    double v = RND.nextDouble() * gauge.getRange() * 1.1 + gauge.getMinValue();
+                    double v = gauge.getRange() * ( RND.nextDouble() * 1.3 - 0.15 ) + gauge.getMinValue();
                     value.set(v);
                     //System.out.println(v);
                     //gauge.setValue(v);

--- a/src/main/java/eu/hansolo/medusa/skins/DigitalSkin.java
+++ b/src/main/java/eu/hansolo/medusa/skins/DigitalSkin.java
@@ -215,7 +215,7 @@ public class DigitalSkin extends GaugeSkinBase {
                         }
                     }
                 } else {
-                    for (int i = minValueAngle; i <= 300; i++) {
+                    for (int i = minValueAngle - 3; i < 300; i++) {
                         if (i % 6 == 0 && i < v) {
                             barCtx.strokeArc(barWidth * 0.5 + barWidth * 0.3, barWidth * 0.5 + barWidth * 0.3, size - barWidth - barWidth * 0.6, size - barWidth - barWidth * 0.6, (-i - 125), 4.6, ArcType.OPEN);
                         }

--- a/src/main/java/eu/hansolo/medusa/skins/DigitalSkin.java
+++ b/src/main/java/eu/hansolo/medusa/skins/DigitalSkin.java
@@ -209,13 +209,13 @@ public class DigitalSkin extends GaugeSkinBase {
         } else {
             if (Double.compare(VALUE, 0) != 0) {
                 if (VALUE < 0) {
-                    for (int i = (minValueAngle - 1); i >= 0; i--) {
+                    for (int i = Math.min(minValueAngle, 300) - 1; i >= 0; i--) {
                         if (i % 6 == 0 && i > v - 6) {
                             barCtx.strokeArc(barWidth * 0.5 + barWidth * 0.3, barWidth * 0.5 + barWidth * 0.3, size - barWidth - barWidth * 0.6, size - barWidth - barWidth * 0.6, (-i - 125), 4.6, ArcType.OPEN);
                         }
                     }
                 } else {
-                    for (int i = minValueAngle - 3; i < 300; i++) {
+                    for (int i = Math.max(minValueAngle, 0) - 3; i < 300; i++) {
                         if (i % 6 == 0 && i < v) {
                             barCtx.strokeArc(barWidth * 0.5 + barWidth * 0.3, barWidth * 0.5 + barWidth * 0.3, size - barWidth - barWidth * 0.6, size - barWidth - barWidth * 0.6, (-i - 125), 4.6, ArcType.OPEN);
                         }


### PR DESCRIPTION
When startFromZero is true, the zero segment was not highlighted for
positive numbers. Moreover values close to maxValue were displayed in a
segment outside the bar limits.