### PR TITLE
Missing REDRAW event when unit is changed

### DIFF
--- a/src/main/java/eu/hansolo/medusa/Gauge.java
+++ b/src/main/java/eu/hansolo/medusa/Gauge.java
@@ -936,6 +936,7 @@ public class Gauge extends Control {
         if (null == unit) {
             _unit = UNIT;
             fireUpdateEvent(VISIBILITY_EVENT);
+            fireUpdateEvent(REDRAW_EVENT);
         } else {
             unit.set(UNIT);
         }
@@ -943,7 +944,10 @@ public class Gauge extends Control {
     public StringProperty unitProperty() {
         if (null == unit) {
             unit  = new StringPropertyBase(_unit) {
-                @Override protected void invalidated() { fireUpdateEvent(VISIBILITY_EVENT); }
+                @Override protected void invalidated() { 
+                    fireUpdateEvent(VISIBILITY_EVENT);
+                    fireUpdateEvent(REDRAW_EVENT);
+                }
                 @Override public Object getBean() { return Gauge.this; }
                 @Override public String getName() { return "unit"; }
             };

--- a/src/main/java/eu/hansolo/medusa/Test.java
+++ b/src/main/java/eu/hansolo/medusa/Test.java
@@ -81,7 +81,7 @@ public class Test extends Application {
                               .build();
 
         gauge = GaugeBuilder.create()
-                            .skinType(SkinType.AMP)
+                            .skinType(SkinType.DIGITAL)
                             //.prefSize(400, 400)
                             .knobPosition(Pos.BOTTOM_LEFT)
                             .tickLabelLocation(TickLabelLocation.OUTSIDE)
@@ -180,6 +180,8 @@ public class Test extends Application {
                         if ( !changed ) {
                             changed = true;
                             clock.setSecondsVisible(false);
+                            gauge.setTitle("LONG TITLE");
+                            gauge.setUnit("\u00B0CCCCCCCC");
                             System.out.println("*** CHANGED");
                         }
                     }


### PR DESCRIPTION
Using DIGITAL skin is possible to notice that changing unit at runtime
it was not updated accordingly.