### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-##Medusa
+## Medusa
 A JavaFX library for Gauges. The main focus of this project is to provide Gauges that can be configured in multiple ways.
 
-##Overview
+## Overview
 ![Overview](https://dl.dropboxusercontent.com/u/84552/medusa/Overview.png)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
