### PR TITLE
Support loading library from multiple classloaders

### DIFF
--- a/src/main/java/eu/hansolo/medusa/Alarm.java
+++ b/src/main/java/eu/hansolo/medusa/Alarm.java
@@ -28,6 +28,7 @@ import javafx.scene.paint.Color;
 
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.UUID;
 
 
 /**
@@ -207,8 +208,8 @@ public class Alarm {
 
     // ******************** Inner Classes *************************************
     public static class AlarmMarkerEvent extends Event {;
-        public static final EventType<AlarmMarkerEvent> ALARM_MARKER_PRESSED  = new EventType(ANY, "ALARM_MARKER_PRESSED");
-        public static final EventType<AlarmMarkerEvent> ALARM_MARKER_RELEASED = new EventType(ANY, "ALARM_MARKER_RELEASED");
+        public static final EventType<AlarmMarkerEvent> ALARM_MARKER_PRESSED  = new EventType(ANY, "ALARM_MARKER_PRESSED" + UUID.randomUUID().toString());
+        public static final EventType<AlarmMarkerEvent> ALARM_MARKER_RELEASED = new EventType(ANY, "ALARM_MARKER_RELEASED" + UUID.randomUUID().toString());
 
 
         // ******************** Constructors **************************************

--- a/src/main/java/eu/hansolo/medusa/Gauge.java
+++ b/src/main/java/eu/hansolo/medusa/Gauge.java
@@ -99,6 +99,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 import java.util.Queue;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Future;
@@ -5624,8 +5625,8 @@ public class Gauge extends Control {
 
     // ******************** Inner Classes *************************************
     public static class ButtonEvent extends Event {
-        public static final EventType<ButtonEvent> BTN_PRESSED  = new EventType<>(ANY, "BTN_PRESSED");
-        public static final EventType<ButtonEvent> BTN_RELEASED = new EventType<>(ANY, "BTN_RELEASED");
+        public static final EventType<ButtonEvent> BTN_PRESSED  = new EventType<>(ANY, "BTN_PRESSED" + UUID.randomUUID().toString());
+        public static final EventType<ButtonEvent> BTN_RELEASED = new EventType<>(ANY, "BTN_RELEASED" + UUID.randomUUID().toString());
 
 
         // ******************** Constructors **************************************
@@ -5634,8 +5635,8 @@ public class Gauge extends Control {
     }
 
     public static class ThresholdEvent extends Event {
-        public static final EventType<ThresholdEvent> THRESHOLD_EXCEEDED = new EventType<>(ANY, "THRESHOLD_EXCEEDED");
-        public static final EventType<ThresholdEvent> THRESHOLD_UNDERRUN = new EventType<>(ANY, "THRESHOLD_UNDERRUN");
+        public static final EventType<ThresholdEvent> THRESHOLD_EXCEEDED = new EventType<>(ANY, "THRESHOLD_EXCEEDED" + UUID.randomUUID().toString());
+        public static final EventType<ThresholdEvent> THRESHOLD_UNDERRUN = new EventType<>(ANY, "THRESHOLD_UNDERRUN" + UUID.randomUUID().toString());
 
 
         // ******************** Constructors **************************************

--- a/src/main/java/eu/hansolo/medusa/Marker.java
+++ b/src/main/java/eu/hansolo/medusa/Marker.java
@@ -16,6 +16,8 @@
 
 package eu.hansolo.medusa;
 
+import java.util.UUID;
+
 import javafx.application.Platform;
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.ObjectProperty;
@@ -322,14 +324,14 @@ public class Marker implements Comparable<Marker>{
 
     // ******************** Inner Classes *************************************
     public static class MarkerEvent extends Event {
-        public static final EventType<MarkerEvent> MARKER_EXCEEDED = new EventType(ANY, "MARKER_EXCEEDED");
-        public static final EventType<MarkerEvent> MARKER_UNDERRUN = new EventType(ANY, "MARKER_UNDER_RUN");
-        public static final EventType<MarkerEvent> MARKER_PRESSED  = new EventType(ANY, "MARKER_PRESSED");
-        public static final EventType<MarkerEvent> MARKER_RELEASED = new EventType(ANY, "MARKER_RELEASED");
-        public static final EventType<MarkerEvent> VALUE_CHANGED   = new EventType(ANY, "VALUE_CHANGED");
-        public static final EventType<MarkerEvent> COLOR_CHANGED   = new EventType(ANY, "COLOR_CHANGED");
-        public static final EventType<MarkerEvent> TEXT_CHANGED    = new EventType(ANY, "TEXT_CHANGED");
-        public static final EventType<MarkerEvent> TYPE_CHANGED    = new EventType(ANY, "TYPE_CHANGED");
+        public static final EventType<MarkerEvent> MARKER_EXCEEDED = new EventType(ANY, "MARKER_EXCEEDED" + UUID.randomUUID().toString());
+        public static final EventType<MarkerEvent> MARKER_UNDERRUN = new EventType(ANY, "MARKER_UNDER_RUN" + UUID.randomUUID().toString());
+        public static final EventType<MarkerEvent> MARKER_PRESSED  = new EventType(ANY, "MARKER_PRESSED" + UUID.randomUUID().toString());
+        public static final EventType<MarkerEvent> MARKER_RELEASED = new EventType(ANY, "MARKER_RELEASED" + UUID.randomUUID().toString());
+        public static final EventType<MarkerEvent> VALUE_CHANGED   = new EventType(ANY, "VALUE_CHANGED" + UUID.randomUUID().toString());
+        public static final EventType<MarkerEvent> COLOR_CHANGED   = new EventType(ANY, "COLOR_CHANGED" + UUID.randomUUID().toString());
+        public static final EventType<MarkerEvent> TEXT_CHANGED    = new EventType(ANY, "TEXT_CHANGED" + UUID.randomUUID().toString());
+        public static final EventType<MarkerEvent> TYPE_CHANGED    = new EventType(ANY, "TYPE_CHANGED" + UUID.randomUUID().toString());
 
 
         // ******************** Constructors **************************************

--- a/src/main/java/eu/hansolo/medusa/Section.java
+++ b/src/main/java/eu/hansolo/medusa/Section.java
@@ -16,6 +16,8 @@
 
 package eu.hansolo.medusa;
 
+import java.util.UUID;
+
 import javafx.beans.property.DoubleProperty;
 import javafx.beans.property.DoublePropertyBase;
 import javafx.beans.property.ObjectProperty;
@@ -408,9 +410,9 @@ public class Section implements Comparable<Section> {
 
     // ******************** Inner Classes *************************************
     public static class SectionEvent extends Event {
-        public static final EventType<SectionEvent> SECTION_ENTERED = new EventType(ANY, "SECTION_ENTERED");
-        public static final EventType<SectionEvent> SECTION_LEFT    = new EventType(ANY, "SECTION_LEFT");
-        public static final EventType<SectionEvent> SECTION_UPDATE  = new EventType(ANY, "SECTION_UPDATE");
+        public static final EventType<SectionEvent> SECTION_ENTERED = new EventType(ANY, "SECTION_ENTERED" + UUID.randomUUID().toString());
+        public static final EventType<SectionEvent> SECTION_LEFT    = new EventType(ANY, "SECTION_LEFT" + UUID.randomUUID().toString());
+        public static final EventType<SectionEvent> SECTION_UPDATE  = new EventType(ANY, "SECTION_UPDATE" + UUID.randomUUID().toString());
 
 
         // ******************** Constructors **************************************

--- a/src/main/java/eu/hansolo/medusa/TimeSection.java
+++ b/src/main/java/eu/hansolo/medusa/TimeSection.java
@@ -28,6 +28,7 @@ import javafx.scene.image.Image;
 import javafx.scene.paint.Color;
 
 import java.time.LocalTime;
+import java.util.UUID;
 
 
 /**
@@ -333,8 +334,8 @@ public class TimeSection implements Comparable<TimeSection> {
 
     // ******************** Inner Classes *************************************
     public static class TimeSectionEvent extends Event {
-        public static final EventType<TimeSectionEvent> TIME_SECTION_ENTERED = new EventType(ANY, "TIME_SECTION_ENTERED");
-        public static final EventType<TimeSectionEvent> TIME_SECTION_LEFT    = new EventType(ANY, "TIME_SECTION_LEFT");
+        public static final EventType<TimeSectionEvent> TIME_SECTION_ENTERED = new EventType(ANY, "TIME_SECTION_ENTERED" + UUID.randomUUID().toString());
+        public static final EventType<TimeSectionEvent> TIME_SECTION_LEFT    = new EventType(ANY, "TIME_SECTION_LEFT" + UUID.randomUUID().toString());
 
         // ******************** Constructors **************************************
         public TimeSectionEvent(final Object SOURCE, final EventTarget TARGET, EventType<TimeSectionEvent> TYPE) {


### PR DESCRIPTION
In applications using a plugin concept where JavaFX is loaded on one classloader and then the plugin is loaded on child classloaders JavaFX will crash due to trying to add the same event name multiple times.

By adding a random UUID to the event name we can avoid these collisions. This solution is also used in e.g. ControlsFX (https://bitbucket.org/controlsfx/controlsfx/pull-requests/686/eventtype-names-use-uuid-suffix-to-prevent/diff)