### PR TITLE
Stop disabled autoScale overriding properties

### DIFF
--- a/src/main/java/eu/hansolo/medusa/GaugeBuilder.java
+++ b/src/main/java/eu/hansolo/medusa/GaugeBuilder.java
@@ -1150,9 +1150,11 @@ public class GaugeBuilder<B extends GaugeBuilder<B>> {
         if (properties.keySet().contains("customTickLabelsList")) {
             CONTROL.setCustomTickLabels(((ObjectProperty<List<String>>) properties.get("customTickLabelsList")).get());
         }
-
         if(properties.keySet().contains("foregroundBaseColor")) {
             CONTROL.setForegroundBaseColor(((ObjectProperty<Color>) properties.get("foregroundBaseColor")).get());
+        }
+        if (properties.keySet().contains("autoScale")) {
+            CONTROL.setAutoScale(((BooleanProperty) properties.get("autoScale")).get());
         }
 
         setMinMaxValues(CONTROL);
@@ -1428,9 +1430,6 @@ public class GaugeBuilder<B extends GaugeBuilder<B>> {
                 CONTROL.setAlertMessage(((StringProperty) properties.get(key)).get());
             } else if ("smoothing".equals(key)) {
                 CONTROL.setSmoothing(((BooleanProperty) properties.get(key)).get());
-            } else if ("autoScale".equals(key)) {
-                CONTROL.setAutoScale(((BooleanProperty) properties.get(key)).get());
-                setMinMaxValues(CONTROL);
             } else if("value".equals(key)) {
                 CONTROL.setValue(((DoubleProperty) properties.get(key)).get());
             }


### PR DESCRIPTION
Fixes a bug where setting the autoScale can still override properties
(even when it is set to "false") because it was being set in the loop
through the HashMap. Consequently, it was possible for autoScale to
override explicit settings (such as tick spacing) even if it is disabled
in the builder.

This was especially happening when autoScale is triggered from setting
another property, such as angleRange.

This also fixes https://github.com/HanSolo/Medusa/issues/200

Signed-off-by: Kah Goh <villastar@yahoo.com.au>