### PR TITLE
fix disposing of gauge skins and its update listener

### DIFF
--- a/src/main/java/eu/hansolo/medusa/skins/GaugeSkinBase.java
+++ b/src/main/java/eu/hansolo/medusa/skins/GaugeSkinBase.java
@@ -49,7 +49,7 @@ public abstract class GaugeSkinBase extends SkinBase<Gauge> implements Skin<Gaug
     protected void registerListeners() {
         getSkinnable().widthProperty().addListener(sizeListener);
         getSkinnable().heightProperty().addListener(sizeListener);
-        getSkinnable().setOnUpdate(e -> handleEvents(e.eventType.name()));
+        getSkinnable().setOnUpdate(updateEventListener);
     }
 
     protected void handleEvents(final String EVENT_TYPE) {


### PR DESCRIPTION
Skins were not properly disposed because an anonymous update listener was used.
The fix simply uses the existing named listener instance that will be removed in dispose()

We stumpled upon this bug when the default GaugeSkin was still handling redraw events and subsequently killed the process when trying to draw millions of radial tick marks.
I assume this will improve the overall performance as well.