### PR TITLE
Remove JavaFX dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -176,7 +176,7 @@ publishing {
                 asNode().dependencies.'*'.findAll {
                     it.groupId.text() == 'org.openjfx'
                 }.each {
-                    it.remove(it.classifier)
+                    it.parent().remove(it)
                 }
             }
         }


### PR DESCRIPTION
While using this plugin, it ignores the user specified JavaFX version and uses the one that this depends on (in this case, 16.0.1 depends on JavaFX 16).

Currently, one needs to do the following in order to use their own specific JavaFX version :

```
<dependency>
            <groupId>eu.hansolo</groupId>
            <artifactId>medusa</artifactId>
            <version>16.0.1</version>
            <exclusions>
                <exclusion>
                    <groupId>org.openjfx</groupId>
                    <artifactId>javafx-graphics</artifactId>
                </exclusion>
                <exclusion>
                    <groupId>org.openjfx</groupId>
                    <artifactId>javafx-controls</artifactId>
                </exclusion>
                <exclusion>
                    <groupId>org.openjfx</groupId>
                    <artifactId>javafx-base</artifactId>
                </exclusion>
                <exclusion>
                    <groupId>org.openjfx</groupId>
                    <artifactId>javafx-swing</artifactId>
                </exclusion>
            </exclusions>
</dependency>
```